### PR TITLE
Add a Clean function that matches apt-get clean

### DIFF
--- a/apt.go
+++ b/apt.go
@@ -173,3 +173,10 @@ func Install(packs ...*Package) (output []byte, err error) {
 	cmd := exec.Command("apt-get", args...)
 	return cmd.CombinedOutput()
 }
+
+// Clean erases downloaded archive files.
+func Clean() (output []byte, err error) {
+	args := []string{"clean"}
+	cmd := exec.Command("apt-get", args...)
+	return cmd.CombinedOutput()
+}


### PR DESCRIPTION
This mimics what's done for other verbs available from `apt-get`.