### PR TITLE
Allow specifying the path when adding a repository

### DIFF
--- a/repos.go
+++ b/repos.go
@@ -172,9 +172,8 @@ func ParseAPTConfigFolder(folderPath string) (RepositoryList, error) {
 }
 
 // AddRepository adds the specified repository by changing the specified APT
-// config folder (usually /etc/apt). The new repository is saved into
-// a file named "managed.list"
-func AddRepository(repo *Repository, configFolderPath string) error {
+// config folder (usually /etc/apt).
+func AddRepository(repo *Repository, configFolderPath, filename string) error {
 	repos, err := ParseAPTConfigFolder(configFolderPath)
 	if err != nil {
 		return fmt.Errorf("parsing APT config: %s", err)
@@ -184,7 +183,7 @@ func AddRepository(repo *Repository, configFolderPath string) error {
 	}
 
 	// Add to the "managed.list" file
-	managedPath := filepath.Join(configFolderPath, "sources.list.d", "managed.list")
+	managedPath := filepath.Join(configFolderPath, "sources.list.d", filename)
 	f, err := os.OpenFile(managedPath, os.O_APPEND|os.O_WRONLY, 0644)
 	if os.IsNotExist(err) {
 		f, err = os.OpenFile(managedPath, os.O_CREATE|os.O_WRONLY, 0644)

--- a/repos_test.go
+++ b/repos_test.go
@@ -67,9 +67,9 @@ func TestAddAndRemoveRepository(t *testing.T) {
 		Components:   "main",
 		Comment:      "",
 	}
-	err := AddRepository(repo1, "testdata/apt2")
+	err := AddRepository(repo1, "testdata/apt2", "managed.list")
 	require.NoError(t, err, "Adding repository")
-	err = AddRepository(repo2, "testdata/apt2")
+	err = AddRepository(repo2, "testdata/apt2", "managed.list")
 	require.NoError(t, err, "Adding repository")
 
 	// check that we have repo1 and repo2 added
@@ -78,7 +78,7 @@ func TestAddAndRemoveRepository(t *testing.T) {
 	require.True(t, repos.Contains(repo1), "Configuration contains: %#v", repo1)
 	require.True(t, repos.Contains(repo2), "Configuration contains: %#v", repo2)
 
-	err = AddRepository(repo2, "testdata/apt2")
+	err = AddRepository(repo2, "testdata/apt2", "managed.list")
 	require.Error(t, err, "Adding repository again")
 
 	// no changes should have happened


### PR DESCRIPTION
There's many cases where adding repositories inconditionally to `sources.list.d/managed.list` is not ideal: it's very common to add an entry per file, ideally named after the repository to add. Configuration management tools for instance follow that pattern. It's also more consistent with other operations not enforcing having a single file for all entries.

Note that while this is a breaking change in the API, I haven't noticed any release of this repository so far, which I take to mean that having such breaking change is alright. If not, I can introduce a new function instead.