### PR TITLE
Fix options rendering in APTConfigLine breaking its output

### DIFF
--- a/repos.go
+++ b/repos.go
@@ -96,7 +96,7 @@ func (r *Repository) APTConfigLine() string {
 		res += "deb "
 	}
 	if strings.TrimSpace(r.Options) != "" {
-		res += "[" + r.Options + "]"
+		res += "[" + r.Options + "] "
 	}
 	res += r.URI + " " + r.Distribution + " " + r.Components
 	if strings.TrimSpace(r.Comment) != "" {

--- a/repos_test.go
+++ b/repos_test.go
@@ -123,3 +123,25 @@ func TestAddAndRemoveRepository(t *testing.T) {
 	require.False(t, repos.Contains(repo1), "Configuration contains: %#v", repo1)
 	require.True(t, repos.Contains(repo2), "Configuration contains: %#v", repo2)
 }
+
+func TestAPTConfigLine(t *testing.T) {
+	r := &Repository{
+		Enabled:      true,
+		SourceRepo:   false,
+		Options:      "signed-by=/etc/apt/keyrings/docker.asc",
+		URI:          "https://download.docker.com/linux/debian",
+		Distribution: "bookworm",
+		Components:   "stable",
+		Comment:      "Docker's Apt repository.",
+	}
+
+	got := r.APTConfigLine()
+	expected := "deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable # Docker's Apt repository."
+	require.True(t, got == expected)
+
+	r.Enabled = false
+	r.SourceRepo = true
+	got = r.APTConfigLine()
+	expected = "# deb-src [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable # Docker's Apt repository."
+	require.True(t, got == expected)
+}


### PR DESCRIPTION
Without that added space, the line generated is actually invalid. Take for instance Docker's apt repository: parsing its apt config line `deb [signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable` will yield a well-formed repository. However, re-generating the line with APTConfigLine from that Repository will yield `deb [signed-by=/etc/apt/keyrings/docker.asc]https://download.docker.com/linux/debian bookworm stable` (note the missing space). This will result in errors such as:
```
Error: Malformed entry 1 in list file /etc/apt/sources.list.d/stable.list ([option] not assignment)
Error: The list of sources could not be read.
```